### PR TITLE
Fixed the NPE when searching for a stock that doesn't exist by doing …

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -64,4 +64,5 @@ dependencies {
     compile 'com.melnykov:floatingactionbutton:1.3.0'
     compile 'net.sf.opencsv:opencsv:2.3'
     compile 'com.github.PhilJay:MPAndroidChart:v3.0.1'
+    compile 'org.greenrobot:eventbus:3.0.0'
 }

--- a/app/src/main/java/com/udacity/stockhawk/Events/SymbolValidationEvent.java
+++ b/app/src/main/java/com/udacity/stockhawk/Events/SymbolValidationEvent.java
@@ -1,0 +1,23 @@
+package com.udacity.stockhawk.Events;
+
+/**
+ * Created by Ben on 12/17/16.
+ */
+
+public class SymbolValidationEvent {
+    Boolean validated;
+    String symbol;
+
+    public SymbolValidationEvent(Boolean validated, String symbol) {
+        this.validated = validated;
+        this.symbol = symbol;
+    }
+
+    public Boolean getValidated() {
+        return this.validated;
+    }
+
+    public String getSymbol() {
+        return this.symbol;
+    }
+}

--- a/app/src/main/java/com/udacity/stockhawk/sync/ValidateSymbol.java
+++ b/app/src/main/java/com/udacity/stockhawk/sync/ValidateSymbol.java
@@ -1,0 +1,45 @@
+package com.udacity.stockhawk.sync;
+
+import android.os.AsyncTask;
+
+import com.udacity.stockhawk.Events.SymbolValidationEvent;
+
+import org.greenrobot.eventbus.EventBus;
+
+import java.io.IOException;
+
+import yahoofinance.Stock;
+import yahoofinance.YahooFinance;
+import yahoofinance.quotes.stock.StockQuote;
+
+import static yahoofinance.YahooFinance.get;
+
+/**
+ * Created by Ben on 12/17/16.
+ */
+
+public class ValidateSymbol extends AsyncTask<String, Void, ValidationResult> {
+
+    @Override
+    protected ValidationResult doInBackground(String... strings) {
+        StockQuote quote = null;
+        Boolean validation;
+        try {
+            quote = YahooFinance.get(strings[0]).getQuote();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        validation = !(quote.getPrice() == null || quote.getChange() == null || quote.getChangeInPercent() == null);
+
+        ValidationResult validationResult = new ValidationResult();
+        validationResult.setValidated(validation);
+        validationResult.setSymbol(strings[0]);
+
+        return validationResult;
+    }
+
+    @Override
+    protected void onPostExecute(ValidationResult result) {
+        EventBus.getDefault().post(new SymbolValidationEvent(result.getValidated(), result.getSymbol()));
+    }
+}

--- a/app/src/main/java/com/udacity/stockhawk/sync/ValidationResult.java
+++ b/app/src/main/java/com/udacity/stockhawk/sync/ValidationResult.java
@@ -1,0 +1,29 @@
+package com.udacity.stockhawk.sync;
+
+/**
+ * Created by Ben on 12/17/16.
+ */
+
+public class ValidationResult {
+    Boolean validated;
+    String symbol;
+
+
+    public String getSymbol() {
+        return symbol;
+    }
+
+    public void setSymbol(String symbol) {
+        this.symbol = symbol;
+    }
+
+    public Boolean getValidated() {
+        return validated;
+    }
+
+    public void setValidated(Boolean validated) {
+        this.validated = validated;
+    }
+
+
+}

--- a/app/src/main/java/com/udacity/stockhawk/ui/MainActivity.java
+++ b/app/src/main/java/com/udacity/stockhawk/ui/MainActivity.java
@@ -19,10 +19,17 @@ import android.view.View;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import com.udacity.stockhawk.Events.SymbolValidationEvent;
 import com.udacity.stockhawk.R;
 import com.udacity.stockhawk.data.Contract;
 import com.udacity.stockhawk.data.PrefUtils;
 import com.udacity.stockhawk.sync.QuoteSyncJob;
+import com.udacity.stockhawk.sync.ValidateSymbol;
+
+import org.greenrobot.eventbus.EventBus;
+import org.greenrobot.eventbus.Subscribe;
+
+import java.io.IOException;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
@@ -77,8 +84,31 @@ public class MainActivity extends AppCompatActivity implements LoaderManager.Loa
                 getContentResolver().delete(Contract.Quote.makeUriForStock(symbol), null, null);
             }
         }).attachToRecyclerView(stockRecyclerView);
+    }
 
+    @Override
+    public void onStart() {
+        super.onStart();
+        EventBus.getDefault().register(this);
+    }
 
+    @Override
+    public void onStop() {
+        super.onStart();
+        EventBus.getDefault().unregister(this);
+    }
+
+    @Subscribe
+    public void onMessageEvent(SymbolValidationEvent event) {
+        Boolean validated = event.getValidated();
+        if (validated) {
+            swipeRefreshLayout.setRefreshing(true);
+            PrefUtils.addStock(this, event.getSymbol());
+            QuoteSyncJob.syncImmediately(this);
+        } else {
+            swipeRefreshLayout.setRefreshing(false);
+            Toast.makeText(this, "u fuckt up", Toast.LENGTH_SHORT).show();
+        }
     }
 
     private boolean networkUp() {
@@ -118,14 +148,12 @@ public class MainActivity extends AppCompatActivity implements LoaderManager.Loa
         if (symbol != null && !symbol.isEmpty()) {
 
             if (networkUp()) {
-                swipeRefreshLayout.setRefreshing(true);
+                ValidateSymbol validator = new ValidateSymbol();
+                validator.execute(symbol);
             } else {
                 String message = getString(R.string.toast_stock_added_no_connectivity, symbol);
                 Toast.makeText(this, message, Toast.LENGTH_LONG).show();
             }
-
-            PrefUtils.addStock(this, symbol);
-            QuoteSyncJob.syncImmediately(this);
         }
     }
 


### PR DESCRIPTION
…the following:

- Execute an AsyncTask that checks whether or not the stock returns values for price, change and change history
- the onPostExecute method of said AsyncTask fires off an event with a boolean saying whether or not the quote had valid data and the string symbol. MainActivity listens for this event, and either toasts an error or adds the stock to SharedPreferences en route to kicking off the QuoteSyncJob